### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/gravstrap-theme.yaml
+++ b/gravstrap-theme.yaml
@@ -2,10 +2,3 @@ enabled: true
 default_lang: en
 dropdown:
   enabled: false
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/gravstrap-theme


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
