### PR TITLE
Update base.html.twig handling favicon image

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -8,7 +8,11 @@
     <title>{% if header.title %}{{ header.title|e('html') }} | {% endif %}{{ site.title|e('html') }}</title>
     {% include 'partials/metadata.html.twig' %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <link rel="icon" type="image/png" href="{{ url('theme://images/favicon.png', true) }}" />
+    {% if page.header.custom_favicon %}
+        <link rel="shortcut icon" type="image/x-icon" href="{{ url('user/pages/images/' ~ page.header.custom_favicon, true) }} " />
+    {% else %}
+        <link rel="shortcut icon" type="image/x-icon" href="{{ url('user/pages/images/favicon.ico', true) }}" />
+    {% endif %}
     <link rel="canonical" href="{{ page.url(true, true) }}" />
 
     {% block stylesheets %}


### PR DESCRIPTION
You create a new folder in the `/user/pages/images` if it is not already there and stick all of your favicons there, you can use any file format the browser accepts, including .ico (usually you use .ico or .png for favicon images) Then if you want to use a custom favicon, on the frontmatter of the page you put this parameter
`custom_favicon: whatever.ico`
If the `custom_favicon` header variable is not there, it will use the default favicon.ico.

You can use `theme://images/` if you prefer to keep everything in the theme images folder, but it is subject to rewriting if you update theme.  User folder or even individual pages folders are more permanent for custom content.